### PR TITLE
Refactoring

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - ci-testing
   pull_request:
     branches:
     - main
@@ -22,10 +21,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
+          components: clippy, rustfmt
       - name: format
-        run: rustup component add rustfmt && cargo fmt --check --manifest-path $GITHUB_WORKSPACE/Cargo.toml
+        run: cargo fmt --all -- --check
       - name: lint
-        run: rustup component add clippy && cargo clippy --manifest-path $GITHUB_WORKSPACE/Cargo.toml -- -Dwarnings
+        run: cargo clippy --all-targets --all-features -- -W clippy::pedantic -D warnings
   test:
     name: test
     strategy:

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["HEx", "GHex", "CNTRLq", ".."]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+use_small_heuristics = "Max"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,22 +1,21 @@
 use std::{
-    cmp,
     error::Error,
     fs::File,
-    io::{Read, Seek, SeekFrom, Write},
+    io::{Read},
     process,
 };
 
 use crossterm::event::{
-    self, Event, KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+    self, Event,
 };
 
 use arboard::Clipboard;
 
 use crate::{
-    input::{Editor, FocusedWindow, InputHandler, JumpToByte},
-    label::{LabelHandler, LABEL_TITLES},
+    input::{self, Editor, InputHandler},
+    label::{LabelHandler},
     screen::{
-        ClickedComponent::{self, AsciiTable, HexTable, Label, Unclickable},
+        ClickedComponent::{self, Unclickable},
         ScreenHandler,
     },
 };
@@ -39,7 +38,7 @@ impl Nibble {
 /// State Information needed by the `ScreenHandler` and `InputHandler`.
 pub(crate) struct AppData {
     /// The file under editting.
-    file: File,
+    pub(crate) file: File,
     /// The file content.
     pub(crate) contents: Vec<u8>,
     /// Offset of the first content byte that is visible on the screen.
@@ -49,19 +48,19 @@ pub(crate) struct AppData {
     /// The nibble that is currently selected in the Hex viewport.
     pub(crate) nibble: Nibble,
     /// The last clicked (key down AND key up) label/window.
-    last_click: ClickedComponent,
+    pub(crate) last_click: ClickedComponent,
     /// Copies label data to your clipboard.
-    clipboard: Option<Clipboard>,
+    pub(crate) clipboard: Option<Clipboard>,
 }
 
 /// Application provides the user interaction interface and renders the terminal screen in response
 /// to user actions.
 pub(crate) struct Application {
     /// The application's state and data.
-    data: AppData,
+    pub(crate) data: AppData,
 
     /// Renders and displays objects to the terminal.
-    display: ScreenHandler,
+    pub(crate) display: ScreenHandler,
 
     /// The labels at the bottom of the UI that provide information
     /// based on the current offset.
@@ -69,10 +68,10 @@ pub(crate) struct Application {
 
     /// The window that handles user input. This is usually in the form of the Hex/ASCII editor
     /// or popups.
-    input_handler: Box<dyn InputHandler>,
+    pub(crate) input_handler: Box<dyn InputHandler>,
 
     /// The input that was most previously selected.
-    last_input_handler: Editor,
+    pub(crate) last_input_handler: Editor,
 }
 
 impl Application {
@@ -124,187 +123,14 @@ impl Application {
     fn handle_input(&mut self) -> Result<bool, Box<dyn Error>> {
         let event = event::read()?;
         match event {
-            Event::Key(key) => match key.code {
-                KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down => {
-                    self.handle_arrow_key_input(key.code);
-                }
-
-                KeyCode::Home => {
-                    self.input_handler
-                        .home(&mut self.data, &mut self.display, &mut self.labels);
-                }
-                KeyCode::End => {
-                    self.input_handler
-                        .end(&mut self.data, &mut self.display, &mut self.labels);
-                }
-
-                KeyCode::Backspace => {
-                    self.input_handler.backspace(
-                        &mut self.data,
-                        &mut self.display,
-                        &mut self.labels,
-                    );
-                }
-                KeyCode::Delete => {
-                    self.input_handler
-                        .delete(&mut self.data, &mut self.display, &mut self.labels);
-                }
-
-                KeyCode::Enter => {
-                    self.input_handler
-                        .enter(&mut self.data, &mut self.display, &mut self.labels);
-                    self.input_handler = Box::from(self.last_input_handler);
-                }
-
-                KeyCode::Char(char) => {
-                    // Because CNTRLq is the signal to quit, we propogate the message
-                    // if this handling method returns false
-                    if !self.handle_character_input(char, key.modifiers)? {
-                        return Ok(false);
-                    };
-                }
-                _ => {}
-            },
+            Event::Key(key) => {
+                return input::handle_key_input(self, key);
+            }
             Event::Mouse(mouse) => {
-                self.handle_mouse_input(mouse);
+                input::handle_mouse_input(self, mouse);
             }
             Event::Resize(_, _) => {}
         }
         Ok(true)
-    }
-    fn handle_arrow_key_input(&mut self, key: KeyCode) {
-        match key {
-            KeyCode::Left => {
-                self.input_handler
-                    .left(&mut self.data, &mut self.display, &mut self.labels);
-            }
-            KeyCode::Right => {
-                self.input_handler
-                    .right(&mut self.data, &mut self.display, &mut self.labels);
-            }
-            KeyCode::Up => {
-                self.input_handler
-                    .up(&mut self.data, &mut self.display, &mut self.labels);
-            }
-            KeyCode::Down => {
-                self.input_handler
-                    .down(&mut self.data, &mut self.display, &mut self.labels);
-            }
-            _ => unreachable!(),
-        }
-    }
-    fn handle_character_input(
-        &mut self,
-        char: char,
-        modifiers: KeyModifiers,
-    ) -> Result<bool, Box<dyn Error>> {
-        if modifiers == KeyModifiers::CONTROL {
-            match char {
-                'j' => {
-                    if self.input_handler.is_focusing(FocusedWindow::JumpToByte) {
-                        self.input_handler = Box::from(self.last_input_handler);
-                    } else {
-                        self.last_input_handler = *self
-                            .input_handler
-                            .as_any()
-                            .downcast_ref()
-                            .expect("The current window wasn't an editor");
-                        self.input_handler = Box::from(JumpToByte::new());
-                    }
-                }
-                'q' => return Ok(false),
-                's' => {
-                    self.data.file.seek(SeekFrom::Start(0))?;
-                    self.data.file.write_all(&self.data.contents)?;
-                    self.data.file.set_len(self.data.contents.len() as u64)?;
-                    self.labels.notification = String::from("Saved!");
-                }
-                _ => {}
-            }
-        } else if modifiers == KeyModifiers::ALT {
-            match char {
-                '=' => {
-                    self.labels
-                        .update_stream_length(cmp::min(self.labels.get_stream_length() + 1, 64));
-                    self.labels
-                        .update_streams(&self.data.contents[self.data.offset..]);
-                }
-                '-' => {
-                    self.labels.update_stream_length(cmp::max(
-                        self.labels.get_stream_length().saturating_sub(1),
-                        0,
-                    ));
-                    self.labels
-                        .update_streams(&self.data.contents[self.data.offset..]);
-                }
-                _ => {}
-            }
-        } else if modifiers | KeyModifiers::NONE | KeyModifiers::SHIFT
-            == KeyModifiers::NONE | KeyModifiers::SHIFT
-        {
-            self.input_handler
-                .char(&mut self.data, &mut self.display, &mut self.labels, char);
-        }
-        Ok(true)
-    }
-    fn handle_mouse_input(&mut self, mouse: MouseEvent) {
-        let component = self.display.identify_clicked_component(
-            mouse.row,
-            mouse.column,
-            self.input_handler.as_ref(),
-        );
-        match mouse.kind {
-            MouseEventKind::Down(MouseButton::Left) => {
-                self.data.last_click = component;
-                match self.data.last_click {
-                    HexTable => {
-                        self.input_handler = Box::from(Editor::Hex);
-                    }
-                    AsciiTable => {
-                        self.input_handler = Box::from(Editor::Ascii);
-                    }
-                    Label(_) | Unclickable => {}
-                }
-            }
-            MouseEventKind::Up(MouseButton::Left) => {
-                match component {
-                    HexTable | AsciiTable | Unclickable => {}
-                    Label(i) => {
-                        if self.data.last_click == component {
-                            // Put string into clipboard
-                            if let Some(clipboard) = self.data.clipboard.as_mut() {
-                                clipboard
-                                    .set_text(self.labels[LABEL_TITLES[i]].clone())
-                                    .unwrap();
-                                self.labels.notification = format!("{} copied!", LABEL_TITLES[i]);
-                            } else {
-                                self.labels.notification = String::from("Can't find clipboard!");
-                            }
-                        }
-                    }
-                }
-            }
-            MouseEventKind::ScrollUp => {
-                let bytes_per_line = self.display.comp_layouts.bytes_per_line;
-
-                // Scroll up a line in the viewport without changing cursor.
-                self.data.start_address = self.data.start_address.saturating_sub(bytes_per_line);
-            }
-            MouseEventKind::ScrollDown => {
-                let bytes_per_line = self.display.comp_layouts.bytes_per_line;
-                let lines_per_screen = self.display.comp_layouts.lines_per_screen;
-
-                let content_lines = self.data.contents.len() / bytes_per_line + 1;
-                let start_row = self.data.start_address / bytes_per_line;
-
-                // Scroll down a line in the viewport without changing cursor.
-                // Until the viewport contains the last page of content.
-                if start_row + lines_per_screen < content_lines {
-                    self.data.start_address =
-                        self.data.start_address.saturating_add(bytes_per_line);
-                }
-            }
-            _ => {}
-        }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,8 @@
+//! The terminal hex editor in its entirety.
+//!
+//! The application holds the main components of the other modules, like the [`ScreenHandler`],
+//! [`LabelHandler`], and input handling, as well as the state data that each of them need.
+
 use std::{error::Error, fs::File, io::Read, process};
 
 use crossterm::event::{self, Event};
@@ -5,14 +10,19 @@ use crossterm::event::{self, Event};
 use arboard::Clipboard;
 
 use crate::{
-    input::{self, Editor, InputHandler},
+    input,
     label::LabelHandler,
     screen::{
         ClickedComponent::{self, Unclickable},
         ScreenHandler,
     },
+    windows::{Editor, KeyHandler},
 };
 
+/// Enum that represent grouping of 4 bits in a byte.
+///
+/// For example, the first nibble in 0XF4 is 1111, or the F in hexadecimal. This is specified by
+/// [`Nibble::Beginning`]. The last four bits (or 4 in hex) would be specified by [`Nibble::End`].
 #[derive(PartialEq)]
 pub(crate) enum Nibble {
     Beginning,
@@ -22,28 +32,37 @@ pub(crate) enum Nibble {
 impl Nibble {
     pub(crate) fn toggle(&mut self) {
         match self {
-            Nibble::Beginning => *self = Nibble::End,
-            Nibble::End => *self = Nibble::Beginning,
+            Self::Beginning => *self = Self::End,
+            Self::End => *self = Self::Beginning,
         }
     }
 }
 
-/// State Information needed by the `ScreenHandler` and `InputHandler`.
+/// State Information needed by the [`ScreenHandler`] and [`KeyHandler`].
 pub(crate) struct AppData {
     /// The file under editting.
     pub(crate) file: File,
+
     /// The file content.
     pub(crate) contents: Vec<u8>,
+
     /// Offset of the first content byte that is visible on the screen.
     pub(crate) start_address: usize,
+
     /// Offset of the content byte under cursor.
     pub(crate) offset: usize,
+
     /// The nibble that is currently selected in the Hex viewport.
     pub(crate) nibble: Nibble,
+
     /// The last clicked (key down AND key up) label/window.
     pub(crate) last_click: ClickedComponent,
+
     /// Copies label data to your clipboard.
     pub(crate) clipboard: Option<Clipboard>,
+
+    /// The editor that is currently selected. This editor will be refocused upon a popup closing.
+    pub(crate) editor: Editor,
 }
 
 /// Application provides the user interaction interface and renders the terminal screen in response
@@ -59,16 +78,17 @@ pub(crate) struct Application {
     /// based on the current offset.
     pub(crate) labels: LabelHandler,
 
-    /// The window that handles user input. This is usually in the form of the Hex/ASCII editor
+    /// The window that handles keyboard input. This is usually in the form of the Hex/ASCII editor
     /// or popups.
-    pub(crate) input_handler: Box<dyn InputHandler>,
-
-    /// The input that was most previously selected.
-    pub(crate) last_input_handler: Editor,
+    pub(crate) key_handler: Box<dyn KeyHandler>,
 }
 
 impl Application {
-    pub(crate) fn new(mut file: File) -> Result<Application, Box<dyn Error>> {
+    /// Creates a new application, focusing the Hex editor and starting with an offset of 0 by
+    /// default. This is called once at the beginning of the program.
+    ///
+    /// This errors out if the file specified is empty.
+    pub(crate) fn new(mut file: File) -> Result<Self, Box<dyn Error>> {
         let mut contents = Vec::new();
         file.read_to_end(&mut contents).expect("Reading the contents of the file was interrupted.");
         if contents.is_empty() {
@@ -80,7 +100,7 @@ impl Application {
         if clipboard.is_none() {
             labels.notification = String::from("Can't find clipboard!");
         }
-        Ok(Application {
+        Ok(Self {
             data: AppData {
                 file,
                 contents,
@@ -89,13 +109,16 @@ impl Application {
                 nibble: Nibble::Beginning,
                 last_click: Unclickable,
                 clipboard,
+                editor: Editor::Hex,
             },
             display: ScreenHandler::new()?,
             labels,
-            last_input_handler: Editor::Hex,
-            input_handler: Box::from(Editor::Hex),
+            key_handler: Box::from(Editor::Hex),
         })
     }
+
+    /// A loop that repeatedly renders the terminal and modifies state based on input. Is stopped
+    /// when input handling receives CNTRLq, the command to stop.
     pub(crate) fn run(&mut self) -> Result<(), Box<dyn Error>> {
         ScreenHandler::setup()?;
         loop {
@@ -107,10 +130,17 @@ impl Application {
         self.display.teardown()?;
         Ok(())
     }
+
+    /// Renders the display. This is a wrapper around [`ScreenHandler`'s
+    /// render](ScreenHandler::render) method.
     fn render_display(&mut self) -> Result<(), Box<dyn Error>> {
-        self.display.render(&self.data, &self.labels, self.input_handler.as_ref())?;
+        self.display.render(&self.data, &self.labels, self.key_handler.as_ref())?;
         Ok(())
     }
+
+    /// Handles all forms of user input. This calls out to code in [input], which uses
+    /// [Application's `key_handler` method](Application::key_handler) to determine what to do for
+    /// key input.
     fn handle_input(&mut self) -> Result<bool, Box<dyn Error>> {
         let event = event::read()?;
         match event {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,19 +1,12 @@
-use std::{
-    error::Error,
-    fs::File,
-    io::{Read},
-    process,
-};
+use std::{error::Error, fs::File, io::Read, process};
 
-use crossterm::event::{
-    self, Event,
-};
+use crossterm::event::{self, Event};
 
 use arboard::Clipboard;
 
 use crate::{
     input::{self, Editor, InputHandler},
-    label::{LabelHandler},
+    label::LabelHandler,
     screen::{
         ClickedComponent::{self, Unclickable},
         ScreenHandler,
@@ -77,8 +70,7 @@ pub(crate) struct Application {
 impl Application {
     pub(crate) fn new(mut file: File) -> Result<Application, Box<dyn Error>> {
         let mut contents = Vec::new();
-        file.read_to_end(&mut contents)
-            .expect("Reading the contents of the file was interrupted.");
+        file.read_to_end(&mut contents).expect("Reading the contents of the file was interrupted.");
         if contents.is_empty() {
             eprintln!("heh does not support editing empty files");
             process::exit(1);
@@ -116,8 +108,7 @@ impl Application {
         Ok(())
     }
     fn render_display(&mut self) -> Result<(), Box<dyn Error>> {
-        self.display
-            .render(&self.data, &self.labels, self.input_handler.as_ref())?;
+        self.display.render(&self.data, &self.labels, self.input_handler.as_ref())?;
         Ok(())
     }
     fn handle_input(&mut self) -> Result<bool, Box<dyn Error>> {

--- a/src/byte.rs
+++ b/src/byte.rs
@@ -1,3 +1,5 @@
+//! Determines how a byte is colored and displayed.
+
 use tui::style::Color;
 pub(crate) enum ByteCategory {
     Null,

--- a/src/byte.rs
+++ b/src/byte.rs
@@ -1,5 +1,4 @@
 use tui::style::Color;
-
 pub(crate) enum ByteCategory {
     Null,
     AsciiPrintable,
@@ -28,19 +27,19 @@ pub(crate) fn category(byte: u8) -> ByteCategory {
     }
 }
 
-pub(crate) fn as_str(byte: &u8) -> String {
-    match category(*byte) {
+pub(crate) fn as_str(byte: u8) -> String {
+    match category(byte) {
         ByteCategory::Null => "0".to_string(),
-        ByteCategory::AsciiPrintable => (*byte as char).to_string(),
-        ByteCategory::AsciiWhitespace if *byte == 0x20 => " ".to_string(),
+        ByteCategory::AsciiPrintable => (byte as char).to_string(),
+        ByteCategory::AsciiWhitespace if byte == 0x20 => " ".to_string(),
         ByteCategory::AsciiWhitespace => "_".to_string(),
         ByteCategory::AsciiOther => "•".to_string(),
         ByteCategory::NonAscii => "×".to_string(),
     }
 }
 
-pub(crate) fn get_color(byte: &u8) -> &'static Color {
-    match category(*byte) {
+pub(crate) fn get_color(byte: u8) -> &'static Color {
+    match category(byte) {
         ByteCategory::Null => &COLOR_NULL,
         ByteCategory::AsciiPrintable => &COLOR_ASCII_PRINTABLE,
         ByteCategory::AsciiWhitespace => &COLOR_ASCII_WHITESPACE,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,300 @@
+use std::{any::Any, cmp};
+
+use crate::{
+    app::{AppData, Nibble},
+    label::LabelHandler,
+    screen::ScreenHandler,
+};
+
+const DEFAULT_INPUT: &'static str = "";
+
+/// A trait for objects which handle input.
+///
+/// Depending on what is currently focused, user input can be handled in different ways. For 
+/// example, pressing enter should not modify the opened file in any form, but doing so while the
+/// "Jump To Byte" popup is focused should attempt to move the cursor to the inputted byte.
+pub(crate) trait InputHandler {
+    /// Downcasts a dynamic `InputHandler` into a specific one.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Checks if the current `InputHandler` is a certain `FocusedWindow`.
+    fn is_focusing(&self, window_type: FocusedWindow) -> bool;
+
+    // Methods that handle their respective keypresses.
+    fn left(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn right(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn up(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn down(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn home(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn end(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn backspace(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn delete(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn enter(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn char(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler, _: char) {}
+
+    /// Returns user input. Is currently just used to get the contents of popups.
+    fn get_user_input(&self) -> &str {
+        DEFAULT_INPUT
+    }
+}
+
+/// An enumeration of all the potential components that could be focused. Used to identify which
+/// component is currently focused in the `Application`'s input field.
+#[derive(PartialEq)]
+pub(crate) enum FocusedWindow {
+    Ascii,
+    Hex,
+    JumpToByte,
+}
+
+/// The main windows that allow users to edit HEX and ASCII.
+#[derive(PartialEq, Clone, Copy)]
+pub(crate) enum Editor {
+    Ascii,
+    Hex,
+}
+
+/// A window that can accept input and attempt to move the cursor to inputted byte.
+#[derive(PartialEq)]
+pub(crate) struct JumpToByte {
+    pub(crate) input: String,
+}
+
+impl InputHandler for Editor {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn is_focusing(&self, window_type: FocusedWindow) -> bool {
+        match self {
+            Editor::Ascii => window_type == FocusedWindow::Ascii,
+            Editor::Hex => window_type == FocusedWindow::Hex,
+        }
+    }
+    fn left(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        match self {
+            Editor::Ascii => {
+                app.offset = app.offset.saturating_sub(1);
+                labels.update_all(&app.contents[app.offset..]);
+                adjust_offset(app, display, labels);
+            }
+            Editor::Hex => {
+                if app.nibble == Nibble::Beginning {
+                    app.offset = app.offset.saturating_sub(1);
+                    labels.update_all(&app.contents[app.offset..]);
+                    adjust_offset(app, display, labels);
+                }
+                app.nibble.toggle();
+            }
+        }
+    }
+    fn right(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        match self {
+            Editor::Ascii => {
+                app.offset = cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
+                labels.update_all(&app.contents[app.offset..]);
+                adjust_offset(app, display, labels);
+            }
+            Editor::Hex => {
+                if app.nibble == Nibble::End {
+                    app.offset = cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
+                    labels.update_all(&app.contents[app.offset..]);
+                    adjust_offset(app, display, labels);
+                }
+                app.nibble.toggle();
+            }
+        }
+    }
+    fn up(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        if let Some(new_offset) = app.offset.checked_sub(display.comp_layouts.bytes_per_line) {
+            app.offset = new_offset;
+            labels.update_all(&app.contents[app.offset..]);
+            adjust_offset(app, display, labels);
+        }
+    }
+    fn down(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        if let Some(new_offset) = app.offset.checked_add(display.comp_layouts.bytes_per_line) {
+            if new_offset < app.contents.len() {
+                app.offset = new_offset;
+                labels.update_all(&app.contents[app.offset..]);
+                adjust_offset(app, display, labels);
+            }
+        }
+    }
+    fn home(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        let bytes_per_line = display.comp_layouts.bytes_per_line;
+        app.offset = app.offset / bytes_per_line * bytes_per_line;
+        labels.update_all(&app.contents[app.offset..]);
+        adjust_offset(app, display, labels);
+
+        if self.is_focusing(FocusedWindow::Hex) {
+            app.nibble = Nibble::Beginning;
+        }
+    }
+    fn end(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        let bytes_per_line = display.comp_layouts.bytes_per_line;
+        app.offset = cmp::min(
+            app.offset + (bytes_per_line - 1 - app.offset % bytes_per_line),
+            app.contents.len() - 1,
+        );
+        labels.update_all(&app.contents[app.offset..]);
+        adjust_offset(app, display, labels);
+
+        if self.is_focusing(FocusedWindow::Hex) {
+            app.nibble = Nibble::End;
+        }
+    }
+    fn backspace(
+        &mut self,
+        app: &mut AppData,
+        display: &mut ScreenHandler,
+        labels: &mut LabelHandler,
+    ) {
+        if app.offset > 0 {
+            app.contents.remove(app.offset - 1);
+            app.offset = app.offset.saturating_sub(1);
+            labels.update_all(&app.contents[app.offset..]);
+            adjust_offset(app, display, labels);
+        }
+    }
+    fn delete(
+        &mut self,
+        app: &mut AppData,
+        display: &mut ScreenHandler,
+        labels: &mut LabelHandler,
+    ) {
+        if app.contents.len() > 1 {
+            app.contents.remove(app.offset);
+            labels.update_all(&app.contents[app.offset..]);
+            adjust_offset(app, display, labels);
+        }
+    }
+    fn char(
+        &mut self,
+        app: &mut AppData,
+        display: &mut ScreenHandler,
+        labels: &mut LabelHandler,
+        c: char,
+    ) {
+        match *self {
+            Editor::Ascii => {
+                app.contents[app.offset] = c as u8;
+                app.offset = cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
+                labels.update_all(&app.contents[app.offset..]);
+                adjust_offset(app, display, labels);
+            }
+            Editor::Hex => {
+                if c.is_ascii_hexdigit() {
+                    // This can probably be optimized...
+                    match app.nibble {
+                        Nibble::Beginning => {
+                            let mut src = c.to_string();
+                            src.push(
+                                format!("{:02X}", app.contents[app.offset])
+                                    .chars()
+                                    .last()
+                                    .unwrap(),
+                            );
+                            let changed = u8::from_str_radix(src.as_str(), 16).unwrap();
+                            app.contents[app.offset] = changed;
+                        }
+                        Nibble::End => {
+                            let mut src = format!("{:02X}", app.contents[app.offset])
+                                .chars()
+                                .take(1)
+                                .collect::<String>();
+                            src.push(c);
+                            let changed = u8::from_str_radix(src.as_str(), 16).unwrap();
+                            app.contents[app.offset] = changed;
+
+                            // Move to the next byte
+                            app.offset =
+                                cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
+                            labels.update_all(&app.contents[app.offset..]);
+                            adjust_offset(app, display, labels);
+                        }
+                    }
+                    app.nibble.toggle();
+                } else {
+                    labels.notification = format!("Invalid Hex: {c}");
+                }
+            }
+        }
+    }
+}
+
+impl InputHandler for JumpToByte {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn is_focusing(&self, window_type: FocusedWindow) -> bool {
+        window_type == FocusedWindow::JumpToByte
+    }
+    fn char(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler, c: char) {
+        self.input.push(c);
+    }
+    fn get_user_input(&self) -> &str {
+        &self.input
+    }
+    fn backspace(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {
+        self.input.pop();
+    }
+    fn enter(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        let new_offset = if self.input.starts_with("0x") {
+            usize::from_str_radix(&self.input[2..], 16)
+        } else {
+            self.input.parse()
+        };
+        if let Ok(new_offset) = new_offset {
+            if new_offset >= app.contents.len() {
+                labels.notification = String::from("Invalid range!");
+            } else {
+                app.offset = new_offset;
+                labels.update_all(&app.contents[app.offset..]);
+                adjust_offset(app, display, labels);
+            }
+        } else {
+            labels.notification = format!("Error: {:?}", new_offset.unwrap_err());
+        }
+    }
+}
+
+impl JumpToByte {
+    pub fn new() -> Self {
+        Self {
+            input: String::new(),
+        }
+    }
+}
+
+/// Moves the starting address of the editor viewports (Hex and ASCII) to include the cursor.
+/// 
+/// If the cursor's location is before the viewports start, the viewports will move so that the
+/// cursor is included in the first row.
+/// 
+/// If the cursor's location is past the end of the viewports, the vierports will move so that
+/// the cursor is included in the final row.
+fn adjust_offset(app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+    let line_adjustment = if app.offset <= app.start_address {
+        app.start_address - app.offset + display.comp_layouts.bytes_per_line - 1
+    } else {
+        app.offset - app.start_address
+    } / display.comp_layouts.bytes_per_line;
+
+    let bytes_per_screen =
+        display.comp_layouts.bytes_per_line * display.comp_layouts.lines_per_screen;
+
+    if app.offset < app.start_address {
+        app.start_address = app
+            .start_address
+            .saturating_sub(display.comp_layouts.bytes_per_line * line_adjustment);
+    } else if app.offset >= app.start_address + (bytes_per_screen)
+        && app.start_address + display.comp_layouts.bytes_per_line < app.contents.len()
+    {
+        app.start_address = app.start_address.saturating_add(
+            display.comp_layouts.bytes_per_line
+                * (line_adjustment + 1 - display.comp_layouts.lines_per_screen),
+        );
+    }
+
+    labels.offset = format!("{:#X}", app.offset);
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -201,10 +201,7 @@ impl InputHandler for Editor {
                         Nibble::Beginning => {
                             let mut src = c.to_string();
                             src.push(
-                                format!("{:02X}", app.contents[app.offset])
-                                    .chars()
-                                    .last()
-                                    .unwrap(),
+                                format!("{:02X}", app.contents[app.offset]).chars().last().unwrap(),
                             );
                             let changed = u8::from_str_radix(src.as_str(), 16).unwrap();
                             app.contents[app.offset] = changed;
@@ -272,9 +269,7 @@ impl InputHandler for JumpToByte {
 
 impl JumpToByte {
     pub(crate) fn new() -> Self {
-        Self {
-            input: String::new(),
-        }
+        Self { input: String::new() }
     }
 }
 
@@ -296,9 +291,8 @@ fn adjust_offset(app: &mut AppData, display: &mut ScreenHandler, labels: &mut La
         display.comp_layouts.bytes_per_line * display.comp_layouts.lines_per_screen;
 
     if app.offset < app.start_address {
-        app.start_address = app
-            .start_address
-            .saturating_sub(display.comp_layouts.bytes_per_line * line_adjustment);
+        app.start_address =
+            app.start_address.saturating_sub(display.comp_layouts.bytes_per_line * line_adjustment);
     } else if app.offset >= app.start_address + (bytes_per_screen)
         && app.start_address + display.comp_layouts.bytes_per_line < app.contents.len()
     {
@@ -317,43 +311,34 @@ pub(crate) fn handle_key_input(
 ) -> Result<bool, Box<dyn Error>> {
     match key.code {
         KeyCode::Left => {
-            app.input_handler
-                .left(&mut app.data, &mut app.display, &mut app.labels);
+            app.input_handler.left(&mut app.data, &mut app.display, &mut app.labels);
         }
         KeyCode::Right => {
-            app.input_handler
-                .right(&mut app.data, &mut app.display, &mut app.labels);
+            app.input_handler.right(&mut app.data, &mut app.display, &mut app.labels);
         }
         KeyCode::Up => {
-            app.input_handler
-                .up(&mut app.data, &mut app.display, &mut app.labels);
+            app.input_handler.up(&mut app.data, &mut app.display, &mut app.labels);
         }
         KeyCode::Down => {
-            app.input_handler
-                .down(&mut app.data, &mut app.display, &mut app.labels);
+            app.input_handler.down(&mut app.data, &mut app.display, &mut app.labels);
         }
 
         KeyCode::Home => {
-            app.input_handler
-                .home(&mut app.data, &mut app.display, &mut app.labels);
+            app.input_handler.home(&mut app.data, &mut app.display, &mut app.labels);
         }
         KeyCode::End => {
-            app.input_handler
-                .end(&mut app.data, &mut app.display, &mut app.labels);
+            app.input_handler.end(&mut app.data, &mut app.display, &mut app.labels);
         }
 
         KeyCode::Backspace => {
-            app.input_handler
-                .backspace(&mut app.data, &mut app.display, &mut app.labels);
+            app.input_handler.backspace(&mut app.data, &mut app.display, &mut app.labels);
         }
         KeyCode::Delete => {
-            app.input_handler
-                .delete(&mut app.data, &mut app.display, &mut app.labels);
+            app.input_handler.delete(&mut app.data, &mut app.display, &mut app.labels);
         }
 
         KeyCode::Enter => {
-            app.input_handler
-                .enter(&mut app.data, &mut app.display, &mut app.labels);
+            app.input_handler.enter(&mut app.data, &mut app.display, &mut app.labels);
             app.input_handler = Box::from(app.last_input_handler);
         }
 
@@ -397,33 +382,28 @@ pub(crate) fn handle_character_input(
     } else if modifiers == KeyModifiers::ALT {
         match char {
             '=' => {
-                app.labels
-                    .update_stream_length(cmp::min(app.labels.get_stream_length() + 1, 64));
-                app.labels
-                    .update_streams(&app.data.contents[app.data.offset..]);
+                app.labels.update_stream_length(cmp::min(app.labels.get_stream_length() + 1, 64));
+                app.labels.update_streams(&app.data.contents[app.data.offset..]);
             }
             '-' => {
                 app.labels.update_stream_length(cmp::max(
                     app.labels.get_stream_length().saturating_sub(1),
                     0,
                 ));
-                app.labels
-                    .update_streams(&app.data.contents[app.data.offset..]);
+                app.labels.update_streams(&app.data.contents[app.data.offset..]);
             }
             _ => {}
         }
     } else if modifiers | KeyModifiers::NONE | KeyModifiers::SHIFT
         == KeyModifiers::NONE | KeyModifiers::SHIFT
     {
-        app.input_handler
-            .char(&mut app.data, &mut app.display, &mut app.labels, char);
+        app.input_handler.char(&mut app.data, &mut app.display, &mut app.labels, char);
     }
     Ok(true)
 }
 pub(crate) fn handle_mouse_input(app: &mut Application, mouse: MouseEvent) {
     let component =
-        app.display
-            .identify_clicked_component(mouse.row, mouse.column, app.input_handler.as_ref());
+        app.display.identify_clicked_component(mouse.row, mouse.column, app.input_handler.as_ref());
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
             app.data.last_click = component;
@@ -444,9 +424,7 @@ pub(crate) fn handle_mouse_input(app: &mut Application, mouse: MouseEvent) {
                     if app.data.last_click == component {
                         // Put string into clipboard
                         if let Some(clipboard) = app.data.clipboard.as_mut() {
-                            clipboard
-                                .set_text(app.labels[LABEL_TITLES[i]].clone())
-                                .unwrap();
+                            clipboard.set_text(app.labels[LABEL_TITLES[i]].clone()).unwrap();
                             app.labels.notification = format!("{} copied!", LABEL_TITLES[i]);
                         } else {
                             app.labels.notification = String::from("Can't find clipboard!");

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,9 @@
+//! Handles user input.
+//!
+//! This is where mouse actions are programmed. It's also a wrapper around calls to a dynamic
+//! [`KeyHandler`](crate::windows::KeyHandler), which handles keyboared input.
+
 use std::{
-    any::Any,
     cmp,
     error::Error,
     io::{Seek, SeekFrom, Write},
@@ -8,338 +12,52 @@ use std::{
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
 use crate::{
-    app::{AppData, Application, Nibble},
-    label::{LabelHandler, LABEL_TITLES},
-    screen::{
-        ClickedComponent::{AsciiTable, HexTable, Label, Unclickable},
-        ScreenHandler,
-    },
+    app::Application,
+    label::LABEL_TITLES,
+    screen::ClickedComponent::{AsciiTable, HexTable, Label, Unclickable},
+    windows::{Editor, FocusedWindow, JumpToByte},
 };
 
-const DEFAULT_INPUT: &str = "";
-
-/// A trait for objects which handle input.
-///
-/// Depending on what is currently focused, user input can be handled in different ways. For
-/// example, pressing enter should not modify the opened file in any form, but doing so while the
-/// "Jump To Byte" popup is focused should attempt to move the cursor to the inputted byte.
-pub(crate) trait InputHandler {
-    /// Downcasts a dynamic `InputHandler` into a specific one.
-    fn as_any(&self) -> &dyn Any;
-
-    /// Checks if the current `InputHandler` is a certain `FocusedWindow`.
-    fn is_focusing(&self, window_type: FocusedWindow) -> bool;
-
-    // Methods that handle their respective keypresses.
-    fn left(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
-    fn right(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
-    fn up(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
-    fn down(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
-    fn home(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
-    fn end(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
-    fn backspace(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
-    fn delete(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
-    fn enter(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
-    fn char(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler, _: char) {}
-
-    /// Returns user input. Is currently just used to get the contents of popups.
-    fn get_user_input(&self) -> &str {
-        DEFAULT_INPUT
-    }
-}
-
-/// An enumeration of all the potential components that could be focused. Used to identify which
-/// component is currently focused in the `Application`'s input field.
-#[derive(PartialEq)]
-pub(crate) enum FocusedWindow {
-    Ascii,
-    Hex,
-    JumpToByte,
-}
-
-/// The main windows that allow users to edit HEX and ASCII.
-#[derive(PartialEq, Clone, Copy)]
-pub(crate) enum Editor {
-    Ascii,
-    Hex,
-}
-
-/// A window that can accept input and attempt to move the cursor to the inputted byte.
-///
-/// The input is either parsed as hexadecimal if it is preceded with "0x", or decimal if not.
-#[derive(PartialEq)]
-pub(crate) struct JumpToByte {
-    pub(crate) input: String,
-}
-
-impl InputHandler for Editor {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn is_focusing(&self, window_type: FocusedWindow) -> bool {
-        match self {
-            Editor::Ascii => window_type == FocusedWindow::Ascii,
-            Editor::Hex => window_type == FocusedWindow::Hex,
-        }
-    }
-    fn left(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
-        match self {
-            Editor::Ascii => {
-                app.offset = app.offset.saturating_sub(1);
-                labels.update_all(&app.contents[app.offset..]);
-                adjust_offset(app, display, labels);
-            }
-            Editor::Hex => {
-                if app.nibble == Nibble::Beginning {
-                    app.offset = app.offset.saturating_sub(1);
-                    labels.update_all(&app.contents[app.offset..]);
-                    adjust_offset(app, display, labels);
-                }
-                app.nibble.toggle();
-            }
-        }
-    }
-    fn right(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
-        match self {
-            Editor::Ascii => {
-                app.offset = cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
-                labels.update_all(&app.contents[app.offset..]);
-                adjust_offset(app, display, labels);
-            }
-            Editor::Hex => {
-                if app.nibble == Nibble::End {
-                    app.offset = cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
-                    labels.update_all(&app.contents[app.offset..]);
-                    adjust_offset(app, display, labels);
-                }
-                app.nibble.toggle();
-            }
-        }
-    }
-    fn up(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
-        if let Some(new_offset) = app.offset.checked_sub(display.comp_layouts.bytes_per_line) {
-            app.offset = new_offset;
-            labels.update_all(&app.contents[app.offset..]);
-            adjust_offset(app, display, labels);
-        }
-    }
-    fn down(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
-        if let Some(new_offset) = app.offset.checked_add(display.comp_layouts.bytes_per_line) {
-            if new_offset < app.contents.len() {
-                app.offset = new_offset;
-                labels.update_all(&app.contents[app.offset..]);
-                adjust_offset(app, display, labels);
-            }
-        }
-    }
-    fn home(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
-        let bytes_per_line = display.comp_layouts.bytes_per_line;
-        app.offset = app.offset / bytes_per_line * bytes_per_line;
-        labels.update_all(&app.contents[app.offset..]);
-        adjust_offset(app, display, labels);
-
-        if self.is_focusing(FocusedWindow::Hex) {
-            app.nibble = Nibble::Beginning;
-        }
-    }
-    fn end(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
-        let bytes_per_line = display.comp_layouts.bytes_per_line;
-        app.offset = cmp::min(
-            app.offset + (bytes_per_line - 1 - app.offset % bytes_per_line),
-            app.contents.len() - 1,
-        );
-        labels.update_all(&app.contents[app.offset..]);
-        adjust_offset(app, display, labels);
-
-        if self.is_focusing(FocusedWindow::Hex) {
-            app.nibble = Nibble::End;
-        }
-    }
-    fn backspace(
-        &mut self,
-        app: &mut AppData,
-        display: &mut ScreenHandler,
-        labels: &mut LabelHandler,
-    ) {
-        if app.offset > 0 {
-            app.contents.remove(app.offset - 1);
-            app.offset = app.offset.saturating_sub(1);
-            labels.update_all(&app.contents[app.offset..]);
-            adjust_offset(app, display, labels);
-        }
-    }
-    fn delete(
-        &mut self,
-        app: &mut AppData,
-        display: &mut ScreenHandler,
-        labels: &mut LabelHandler,
-    ) {
-        if app.contents.len() > 1 {
-            app.contents.remove(app.offset);
-            labels.update_all(&app.contents[app.offset..]);
-            adjust_offset(app, display, labels);
-        }
-    }
-    fn char(
-        &mut self,
-        app: &mut AppData,
-        display: &mut ScreenHandler,
-        labels: &mut LabelHandler,
-        c: char,
-    ) {
-        match *self {
-            Editor::Ascii => {
-                app.contents[app.offset] = c as u8;
-                app.offset = cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
-                labels.update_all(&app.contents[app.offset..]);
-                adjust_offset(app, display, labels);
-            }
-            Editor::Hex => {
-                if c.is_ascii_hexdigit() {
-                    // This can probably be optimized...
-                    match app.nibble {
-                        Nibble::Beginning => {
-                            let mut src = c.to_string();
-                            src.push(
-                                format!("{:02X}", app.contents[app.offset]).chars().last().unwrap(),
-                            );
-                            let changed = u8::from_str_radix(src.as_str(), 16).unwrap();
-                            app.contents[app.offset] = changed;
-                        }
-                        Nibble::End => {
-                            let mut src = format!("{:02X}", app.contents[app.offset])
-                                .chars()
-                                .take(1)
-                                .collect::<String>();
-                            src.push(c);
-                            let changed = u8::from_str_radix(src.as_str(), 16).unwrap();
-                            app.contents[app.offset] = changed;
-
-                            // Move to the next byte
-                            app.offset =
-                                cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
-                            labels.update_all(&app.contents[app.offset..]);
-                            adjust_offset(app, display, labels);
-                        }
-                    }
-                    app.nibble.toggle();
-                } else {
-                    labels.notification = format!("Invalid Hex: {c}");
-                }
-            }
-        }
-    }
-}
-
-impl InputHandler for JumpToByte {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn is_focusing(&self, window_type: FocusedWindow) -> bool {
-        window_type == FocusedWindow::JumpToByte
-    }
-    fn char(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler, c: char) {
-        self.input.push(c);
-    }
-    fn get_user_input(&self) -> &str {
-        &self.input
-    }
-    fn backspace(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {
-        self.input.pop();
-    }
-    fn enter(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
-        let new_offset = if self.input.starts_with("0x") {
-            usize::from_str_radix(&self.input[2..], 16)
-        } else {
-            self.input.parse()
-        };
-        if let Ok(new_offset) = new_offset {
-            if new_offset >= app.contents.len() {
-                labels.notification = String::from("Invalid range!");
-            } else {
-                app.offset = new_offset;
-                labels.update_all(&app.contents[app.offset..]);
-                adjust_offset(app, display, labels);
-            }
-        } else {
-            labels.notification = format!("Error: {:?}", new_offset.unwrap_err());
-        }
-    }
-}
-
-impl JumpToByte {
-    pub(crate) fn new() -> Self {
-        Self { input: String::new() }
-    }
-}
-
-/// Moves the starting address of the editor viewports (Hex and ASCII) to include the cursor.
-///
-/// If the cursor's location is before the viewports start, the viewports will move so that the
-/// cursor is included in the first row.
-///
-/// If the cursor's location is past the end of the viewports, the vierports will move so that
-/// the cursor is included in the final row.
-fn adjust_offset(app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
-    let line_adjustment = if app.offset <= app.start_address {
-        app.start_address - app.offset + display.comp_layouts.bytes_per_line - 1
-    } else {
-        app.offset - app.start_address
-    } / display.comp_layouts.bytes_per_line;
-
-    let bytes_per_screen =
-        display.comp_layouts.bytes_per_line * display.comp_layouts.lines_per_screen;
-
-    if app.offset < app.start_address {
-        app.start_address =
-            app.start_address.saturating_sub(display.comp_layouts.bytes_per_line * line_adjustment);
-    } else if app.offset >= app.start_address + (bytes_per_screen)
-        && app.start_address + display.comp_layouts.bytes_per_line < app.contents.len()
-    {
-        app.start_address = app.start_address.saturating_add(
-            display.comp_layouts.bytes_per_line
-                * (line_adjustment + 1 - display.comp_layouts.lines_per_screen),
-        );
-    }
-
-    labels.offset = format!("{:#X}", app.offset);
-}
-
+/// Wrapper function that calls the corresponding [`KeyHandler`](crate::windows::KeyHandler) methods of
+/// [the application's `key_handler`.](Application::key_handler)
 pub(crate) fn handle_key_input(
     app: &mut Application,
     key: KeyEvent,
 ) -> Result<bool, Box<dyn Error>> {
     match key.code {
+        // Arrow key input
         KeyCode::Left => {
-            app.input_handler.left(&mut app.data, &mut app.display, &mut app.labels);
+            app.key_handler.left(&mut app.data, &mut app.display, &mut app.labels);
         }
         KeyCode::Right => {
-            app.input_handler.right(&mut app.data, &mut app.display, &mut app.labels);
+            app.key_handler.right(&mut app.data, &mut app.display, &mut app.labels);
         }
         KeyCode::Up => {
-            app.input_handler.up(&mut app.data, &mut app.display, &mut app.labels);
+            app.key_handler.up(&mut app.data, &mut app.display, &mut app.labels);
         }
         KeyCode::Down => {
-            app.input_handler.down(&mut app.data, &mut app.display, &mut app.labels);
+            app.key_handler.down(&mut app.data, &mut app.display, &mut app.labels);
         }
 
+        // Cursor shortcuts
         KeyCode::Home => {
-            app.input_handler.home(&mut app.data, &mut app.display, &mut app.labels);
+            app.key_handler.home(&mut app.data, &mut app.display, &mut app.labels);
         }
         KeyCode::End => {
-            app.input_handler.end(&mut app.data, &mut app.display, &mut app.labels);
+            app.key_handler.end(&mut app.data, &mut app.display, &mut app.labels);
         }
 
+        // Removals
         KeyCode::Backspace => {
-            app.input_handler.backspace(&mut app.data, &mut app.display, &mut app.labels);
+            app.key_handler.backspace(&mut app.data, &mut app.display, &mut app.labels);
         }
         KeyCode::Delete => {
-            app.input_handler.delete(&mut app.data, &mut app.display, &mut app.labels);
+            app.key_handler.delete(&mut app.data, &mut app.display, &mut app.labels);
         }
 
         KeyCode::Enter => {
-            app.input_handler.enter(&mut app.data, &mut app.display, &mut app.labels);
-            app.input_handler = Box::from(app.last_input_handler);
+            app.key_handler.enter(&mut app.data, &mut app.display, &mut app.labels);
+            app.key_handler = Box::from(app.data.editor);
         }
 
         KeyCode::Char(char) => {
@@ -359,15 +77,15 @@ pub(crate) fn handle_character_input(
     if modifiers == KeyModifiers::CONTROL {
         match char {
             'j' => {
-                if app.input_handler.is_focusing(FocusedWindow::JumpToByte) {
-                    app.input_handler = Box::from(app.last_input_handler);
+                if app.key_handler.is_focusing(FocusedWindow::JumpToByte) {
+                    app.key_handler = Box::from(app.data.editor);
                 } else {
-                    app.last_input_handler = *app
-                        .input_handler
+                    app.data.editor = *app
+                        .key_handler
                         .as_any()
                         .downcast_ref()
                         .expect("The current window wasn't an editor");
-                    app.input_handler = Box::from(JumpToByte::new());
+                    app.key_handler = Box::from(JumpToByte::new());
                 }
             }
             'q' => return Ok(false),
@@ -397,22 +115,22 @@ pub(crate) fn handle_character_input(
     } else if modifiers | KeyModifiers::NONE | KeyModifiers::SHIFT
         == KeyModifiers::NONE | KeyModifiers::SHIFT
     {
-        app.input_handler.char(&mut app.data, &mut app.display, &mut app.labels, char);
+        app.key_handler.char(&mut app.data, &mut app.display, &mut app.labels, char);
     }
     Ok(true)
 }
 pub(crate) fn handle_mouse_input(app: &mut Application, mouse: MouseEvent) {
     let component =
-        app.display.identify_clicked_component(mouse.row, mouse.column, app.input_handler.as_ref());
+        app.display.identify_clicked_component(mouse.row, mouse.column, app.key_handler.as_ref());
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
             app.data.last_click = component;
             match app.data.last_click {
                 HexTable => {
-                    app.input_handler = Box::from(Editor::Hex);
+                    app.key_handler = Box::from(Editor::Hex);
                 }
                 AsciiTable => {
-                    app.input_handler = Box::from(Editor::Ascii);
+                    app.key_handler = Box::from(Editor::Ascii);
                 }
                 Label(_) | Unclickable => {}
             }

--- a/src/label.rs
+++ b/src/label.rs
@@ -69,9 +69,7 @@ impl Index<&str> for LabelHandler {
 
 impl LabelHandler {
     pub(crate) fn new(bytes: &[u8]) -> Self {
-        let mut labels = LabelHandler {
-            ..Default::default()
-        };
+        let mut labels = LabelHandler { ..Default::default() };
         labels.update_stream_length(8);
         labels.update_all(bytes);
         labels.offset = String::from("0x0");
@@ -155,18 +153,12 @@ impl LabelHandler {
             .collect();
     }
     fn update_octal(&mut self, bytes: &[u8]) {
-        self.octal = bytes
-            .iter()
-            .map(|byte| format!("{byte:03o}"))
-            .collect::<Vec<String>>()
-            .join(" ");
+        self.octal =
+            bytes.iter().map(|byte| format!("{byte:03o}")).collect::<Vec<String>>().join(" ");
     }
     fn update_hexadecimal(&mut self, bytes: &[u8]) {
-        self.hexadecimal = bytes
-            .iter()
-            .map(|byte| format!("{byte:02X}"))
-            .collect::<Vec<String>>()
-            .join(" ");
+        self.hexadecimal =
+            bytes.iter().map(|byte| format!("{byte:02X}")).collect::<Vec<String>>().join(" ");
     }
 }
 

--- a/src/label.rs
+++ b/src/label.rs
@@ -1,3 +1,5 @@
+//! Labels in the bottom half of the terminal UI that provide information based on cursor position.
+
 #![allow(clippy::cast_possible_wrap)]
 use std::ops::Index;
 
@@ -22,19 +24,19 @@ pub(crate) static LABEL_TITLES: [&str; 16] = [
 
 #[derive(Default)]
 pub(crate) struct LabelHandler {
-    pub(crate) signed_eight: String,
-    pub(crate) signed_sixteen: String,
-    pub(crate) signed_thirtytwo: String,
-    pub(crate) signed_sixtyfour: String,
-    pub(crate) unsigned_eight: String,
-    pub(crate) unsigned_sixteen: String,
-    pub(crate) unsigned_thirtytwo: String,
-    pub(crate) unsigned_sixtyfour: String,
-    pub(crate) float_thirtytwo: String,
-    pub(crate) float_sixtyfour: String,
-    pub(crate) binary: String,
-    pub(crate) octal: String,
-    pub(crate) hexadecimal: String,
+    signed_eight: String,
+    signed_sixteen: String,
+    signed_thirtytwo: String,
+    signed_sixtyfour: String,
+    unsigned_eight: String,
+    unsigned_sixteen: String,
+    unsigned_thirtytwo: String,
+    unsigned_sixtyfour: String,
+    float_thirtytwo: String,
+    float_sixtyfour: String,
+    binary: String,
+    octal: String,
+    hexadecimal: String,
     stream_length: usize,
     stream_length_string: String,
     pub(crate) offset: String,
@@ -69,7 +71,7 @@ impl Index<&str> for LabelHandler {
 
 impl LabelHandler {
     pub(crate) fn new(bytes: &[u8]) -> Self {
-        let mut labels = LabelHandler { ..Default::default() };
+        let mut labels = Self { ..Default::default() };
         labels.update_stream_length(8);
         labels.update_all(bytes);
         labels.offset = String::from("0x0");
@@ -110,7 +112,7 @@ impl LabelHandler {
         self.stream_length = length;
         self.stream_length_string = self.stream_length.to_string();
     }
-    pub(crate) fn get_stream_length(&self) -> usize {
+    pub(crate) const fn get_stream_length(&self) -> usize {
         self.stream_length
     }
     fn update_signed_eight(&mut self, bytes: &[u8]) {

--- a/src/label.rs
+++ b/src/label.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::cast_possible_wrap)]
 use std::ops::Index;
 
 pub(crate) static LABEL_TITLES: [&str; 16] = [
@@ -139,17 +140,16 @@ impl LabelHandler {
         self.unsigned_sixtyfour = u64::from_le_bytes(bytes.try_into().unwrap()).to_string();
     }
     fn update_float_thirtytwo(&mut self, bytes: &[u8]) {
-        self.float_thirtytwo = format!("{:e}", f32::from_le_bytes(bytes.try_into().unwrap()))
+        self.float_thirtytwo = format!("{:e}", f32::from_le_bytes(bytes.try_into().unwrap()));
     }
     fn update_float_sixtyfour(&mut self, bytes: &[u8]) {
-        self.float_sixtyfour = format!("{:e}", f64::from_le_bytes(bytes.try_into().unwrap()))
+        self.float_sixtyfour = format!("{:e}", f64::from_le_bytes(bytes.try_into().unwrap()));
     }
     fn update_binary(&mut self, bytes: &[u8]) {
         self.binary = bytes
             .iter()
             .map(|byte| format!("{byte:08b}"))
-            .collect::<Vec<String>>()
-            .join("")
+            .collect::<String>()
             .chars()
             .take(self.stream_length)
             .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use app::Application;
 
 mod app;
 mod byte;
+mod input;
 mod label;
 mod screen;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,11 @@
+//! The HEx Helper is a cross-platform terminal UI used for modifying file data in hex or ASCII.
+//! It aims to replicate some of the look of [hexyl](https://github.com/sharkdp/hexyl) while
+//! functionaly acting like a terminal UI version of [GHex](https://wiki.gnome.org/Apps/Ghex).
+//!
+//! **heh is currently in alpha** - it's not ready to be used in any production manner. Notably, it
+//! does not warn users of quitting before saving, it does not store backups if killed or crashing,
+//! and there is no undo option after deleting a byte.
+
 use std::{error::Error, fs::OpenOptions, io, process};
 
 use crossterm::tty::IsTty;
@@ -9,6 +17,7 @@ mod byte;
 mod input;
 mod label;
 mod screen;
+mod windows;
 
 use clap::{arg, command};
 
@@ -41,6 +50,7 @@ Left-clicking on the ASCII or hex table will focus it.
 
 Zooming in and out will change the size of the components.";
 
+/// Opens the specified file, creates a new application and runs it!
 fn main() -> Result<(), Box<dyn Error>> {
     let matches = command!()
         .about(ABOUT)

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -70,11 +70,7 @@ impl ScreenHandler {
     }
     pub(crate) fn teardown(&mut self) -> Result<(), Box<dyn Error>> {
         disable_raw_mode()?;
-        execute!(
-            self.terminal.backend_mut(),
-            LeaveAlternateScreen,
-            DisableMouseCapture
-        )?;
+        execute!(self.terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
         self.terminal.show_cursor()?;
         Ok(())
     }
@@ -333,11 +329,8 @@ impl ScreenHandler {
             // Render Info
             for (i, label) in self.comp_layouts.labels.iter().enumerate() {
                 f.render_widget(
-                    Paragraph::new(labels[LABEL_TITLES[i]].clone()).block(
-                        Block::default()
-                            .borders(Borders::ALL)
-                            .title(LABEL_TITLES[i]),
-                    ),
+                    Paragraph::new(labels[LABEL_TITLES[i]].clone())
+                        .block(Block::default().borders(Borders::ALL).title(LABEL_TITLES[i])),
                     *label,
                 );
             }

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -62,7 +62,7 @@ impl ScreenHandler {
             comp_layouts: Self::calculate_dimensions(terminal_size),
         })
     }
-    pub(crate) fn setup(&self) -> Result<(), Box<dyn Error>> {
+    pub(crate) fn setup() -> Result<(), Box<dyn Error>> {
         enable_raw_mode()?;
         execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
         Ok(())
@@ -134,7 +134,7 @@ impl ScreenHandler {
                         Constraint::Ratio(1, 4),
                     ])
                     .split(label),
-            )
+            );
         }
 
         // Calculate popup dimensions
@@ -186,7 +186,7 @@ impl ScreenHandler {
                 Spans::from(
                     chunk
                         .iter()
-                        .map(|byte| {
+                        .map(|&byte| {
                             Span::styled(
                                 format!("{byte:02X?} "),
                                 Style::default().fg(*get_color(byte)),
@@ -205,7 +205,7 @@ impl ScreenHandler {
                 Spans::from(
                     chunk
                         .iter()
-                        .map(|byte| {
+                        .map(|&byte| {
                             Span::styled(as_str(byte), Style::default().fg(*get_color(byte)))
                         })
                         .collect::<Vec<Span>>(),
@@ -223,9 +223,9 @@ impl ScreenHandler {
             hex_text[cursor_row - start_row].0[cursor_col] = Span::styled(
                 byte.next().unwrap().to_string(),
                 if nibble == &Nibble::Beginning {
-                    Style::default().fg(*get_color(&cursor_byte)).bg(COLOR_NULL)
+                    Style::default().fg(*get_color(cursor_byte)).bg(COLOR_NULL)
                 } else {
-                    Style::default().fg(*get_color(&cursor_byte))
+                    Style::default().fg(*get_color(cursor_byte))
                 },
             );
             hex_text[cursor_row - start_row].0.insert(
@@ -233,9 +233,9 @@ impl ScreenHandler {
                 Span::styled(
                     byte.next().unwrap().to_string(),
                     if nibble == &Nibble::End {
-                        Style::default().fg(*get_color(&cursor_byte)).bg(COLOR_NULL)
+                        Style::default().fg(*get_color(cursor_byte)).bg(COLOR_NULL)
                     } else {
-                        Style::default().fg(*get_color(&cursor_byte))
+                        Style::default().fg(*get_color(cursor_byte))
                     },
                 ),
             );
@@ -245,8 +245,8 @@ impl ScreenHandler {
 
             // Highlight the selected byte in the ASCII table
             ascii_text[cursor_row - start_row].0[cursor_col] = Span::styled(
-                as_str(&cursor_byte),
-                Style::default().fg(*get_color(&cursor_byte)).bg(COLOR_NULL),
+                as_str(cursor_byte),
+                Style::default().fg(*get_color(cursor_byte)).bg(COLOR_NULL),
             );
         }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,306 @@
+//! The components that implement [`KeyHandler`], which allow them to uniquely react to user input.
+
+use std::{any::Any, cmp};
+
+use crate::{
+    app::{AppData, Nibble},
+    label::LabelHandler,
+    screen::ScreenHandler,
+};
+
+const DEFAULT_INPUT: &str = "";
+
+/// A trait for objects which handle input.
+///
+/// Depending on what is currently focused, user input can be handled in different ways. For
+/// example, pressing enter should not modify the opened file in any form, but doing so while the
+/// "Jump To Byte" popup is focused should attempt to move the cursor to the inputted byte.
+pub(crate) trait KeyHandler {
+    /// Downcasts a dynamic [`KeyHandler`] into a specific one.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Checks if the current [`KeyHandler`] is a certain [`FocusedWindow`].
+    fn is_focusing(&self, window_type: FocusedWindow) -> bool;
+
+    // Methods that handle their respective keypresses.
+    fn left(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn right(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn up(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn down(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn home(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn end(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn backspace(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn delete(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn enter(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+    fn char(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler, _: char) {}
+
+    /// Returns user input. Is currently just used to get the contents of popups.
+    fn get_user_input(&self) -> &str {
+        DEFAULT_INPUT
+    }
+}
+
+/// An enumeration of all the potential components that could be focused. Used to identify which
+/// component is currently focused in the `Application`'s input field.
+#[derive(PartialEq, Eq)]
+pub enum FocusedWindow {
+    Ascii,
+    Hex,
+    JumpToByte,
+}
+
+/// The main windows that allow users to edit HEX and ASCII.
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum Editor {
+    Ascii,
+    Hex,
+}
+
+/// A window that can accept input and attempt to move the cursor to the inputted byte.
+///
+/// This can be opened by pressing `CNTRLj`.
+///
+/// The input is either parsed as hexadecimal if it is preceded with "0x", or decimal if not.
+#[derive(PartialEq, Eq)]
+pub struct JumpToByte {
+    pub input: String,
+}
+
+impl KeyHandler for Editor {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn is_focusing(&self, window_type: FocusedWindow) -> bool {
+        match self {
+            Self::Ascii => window_type == FocusedWindow::Ascii,
+            Self::Hex => window_type == FocusedWindow::Hex,
+        }
+    }
+    fn left(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        match self {
+            Self::Ascii => {
+                app.offset = app.offset.saturating_sub(1);
+                labels.update_all(&app.contents[app.offset..]);
+                adjust_offset(app, display, labels);
+            }
+            Self::Hex => {
+                if app.nibble == Nibble::Beginning {
+                    app.offset = app.offset.saturating_sub(1);
+                    labels.update_all(&app.contents[app.offset..]);
+                    adjust_offset(app, display, labels);
+                }
+                app.nibble.toggle();
+            }
+        }
+    }
+    fn right(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        match self {
+            Self::Ascii => {
+                app.offset = cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
+                labels.update_all(&app.contents[app.offset..]);
+                adjust_offset(app, display, labels);
+            }
+            Self::Hex => {
+                if app.nibble == Nibble::End {
+                    app.offset = cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
+                    labels.update_all(&app.contents[app.offset..]);
+                    adjust_offset(app, display, labels);
+                }
+                app.nibble.toggle();
+            }
+        }
+    }
+    fn up(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        if let Some(new_offset) = app.offset.checked_sub(display.comp_layouts.bytes_per_line) {
+            app.offset = new_offset;
+            labels.update_all(&app.contents[app.offset..]);
+            adjust_offset(app, display, labels);
+        }
+    }
+    fn down(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        if let Some(new_offset) = app.offset.checked_add(display.comp_layouts.bytes_per_line) {
+            if new_offset < app.contents.len() {
+                app.offset = new_offset;
+                labels.update_all(&app.contents[app.offset..]);
+                adjust_offset(app, display, labels);
+            }
+        }
+    }
+    fn home(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        let bytes_per_line = display.comp_layouts.bytes_per_line;
+        app.offset = app.offset / bytes_per_line * bytes_per_line;
+        labels.update_all(&app.contents[app.offset..]);
+        adjust_offset(app, display, labels);
+
+        if self.is_focusing(FocusedWindow::Hex) {
+            app.nibble = Nibble::Beginning;
+        }
+    }
+    fn end(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        let bytes_per_line = display.comp_layouts.bytes_per_line;
+        app.offset = cmp::min(
+            app.offset + (bytes_per_line - 1 - app.offset % bytes_per_line),
+            app.contents.len() - 1,
+        );
+        labels.update_all(&app.contents[app.offset..]);
+        adjust_offset(app, display, labels);
+
+        if self.is_focusing(FocusedWindow::Hex) {
+            app.nibble = Nibble::End;
+        }
+    }
+    fn backspace(
+        &mut self,
+        app: &mut AppData,
+        display: &mut ScreenHandler,
+        labels: &mut LabelHandler,
+    ) {
+        if app.offset > 0 {
+            app.contents.remove(app.offset - 1);
+            app.offset = app.offset.saturating_sub(1);
+            labels.update_all(&app.contents[app.offset..]);
+            adjust_offset(app, display, labels);
+        }
+    }
+    fn delete(
+        &mut self,
+        app: &mut AppData,
+        display: &mut ScreenHandler,
+        labels: &mut LabelHandler,
+    ) {
+        if app.contents.len() > 1 {
+            app.contents.remove(app.offset);
+            labels.update_all(&app.contents[app.offset..]);
+            adjust_offset(app, display, labels);
+        }
+    }
+    fn char(
+        &mut self,
+        app: &mut AppData,
+        display: &mut ScreenHandler,
+        labels: &mut LabelHandler,
+        c: char,
+    ) {
+        match *self {
+            Self::Ascii => {
+                app.contents[app.offset] = c as u8;
+                app.offset = cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
+                labels.update_all(&app.contents[app.offset..]);
+                adjust_offset(app, display, labels);
+            }
+            Self::Hex => {
+                if c.is_ascii_hexdigit() {
+                    // This can probably be optimized...
+                    match app.nibble {
+                        Nibble::Beginning => {
+                            let mut src = c.to_string();
+                            src.push(
+                                format!("{:02X}", app.contents[app.offset]).chars().last().unwrap(),
+                            );
+                            let changed = u8::from_str_radix(src.as_str(), 16).unwrap();
+                            app.contents[app.offset] = changed;
+                        }
+                        Nibble::End => {
+                            let mut src = format!("{:02X}", app.contents[app.offset])
+                                .chars()
+                                .take(1)
+                                .collect::<String>();
+                            src.push(c);
+                            let changed = u8::from_str_radix(src.as_str(), 16).unwrap();
+                            app.contents[app.offset] = changed;
+
+                            // Move to the next byte
+                            app.offset =
+                                cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
+                            labels.update_all(&app.contents[app.offset..]);
+                            adjust_offset(app, display, labels);
+                        }
+                    }
+                    app.nibble.toggle();
+                } else {
+                    labels.notification = format!("Invalid Hex: {c}");
+                }
+            }
+        }
+    }
+
+    fn enter(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {}
+
+    fn get_user_input(&self) -> &str {
+        DEFAULT_INPUT
+    }
+}
+
+impl KeyHandler for JumpToByte {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn is_focusing(&self, window_type: FocusedWindow) -> bool {
+        window_type == FocusedWindow::JumpToByte
+    }
+    fn char(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler, c: char) {
+        self.input.push(c);
+    }
+    fn get_user_input(&self) -> &str {
+        &self.input
+    }
+    fn backspace(&mut self, _: &mut AppData, _: &mut ScreenHandler, _: &mut LabelHandler) {
+        self.input.pop();
+    }
+    fn enter(&mut self, app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+        let new_offset = if self.input.starts_with("0x") {
+            usize::from_str_radix(&self.input[2..], 16)
+        } else {
+            self.input.parse()
+        };
+        if let Ok(new_offset) = new_offset {
+            if new_offset >= app.contents.len() {
+                labels.notification = String::from("Invalid range!");
+            } else {
+                app.offset = new_offset;
+                labels.update_all(&app.contents[app.offset..]);
+                adjust_offset(app, display, labels);
+            }
+        } else {
+            labels.notification = format!("Error: {:?}", new_offset.unwrap_err());
+        }
+    }
+}
+
+impl JumpToByte {
+    pub fn new() -> Self {
+        Self { input: String::new() }
+    }
+}
+
+/// Moves the starting address of the editor viewports (Hex and ASCII) to include the cursor.
+///
+/// If the cursor's location is before the viewports start, the viewports will move so that the
+/// cursor is included in the first row.
+///
+/// If the cursor's location is past the end of the viewports, the vierports will move so that
+/// the cursor is included in the final row.
+fn adjust_offset(app: &mut AppData, display: &mut ScreenHandler, labels: &mut LabelHandler) {
+    let line_adjustment = if app.offset <= app.start_address {
+        app.start_address - app.offset + display.comp_layouts.bytes_per_line - 1
+    } else {
+        app.offset - app.start_address
+    } / display.comp_layouts.bytes_per_line;
+
+    let bytes_per_screen =
+        display.comp_layouts.bytes_per_line * display.comp_layouts.lines_per_screen;
+
+    if app.offset < app.start_address {
+        app.start_address =
+            app.start_address.saturating_sub(display.comp_layouts.bytes_per_line * line_adjustment);
+    } else if app.offset >= app.start_address + (bytes_per_screen)
+        && app.start_address + display.comp_layouts.bytes_per_line < app.contents.len()
+    {
+        app.start_address = app.start_address.saturating_add(
+            display.comp_layouts.bytes_per_line
+                * (line_adjustment + 1 - display.comp_layouts.lines_per_screen),
+        );
+    }
+
+    labels.offset = format!("{:#X}", app.offset);
+}


### PR DESCRIPTION
Fixes #20 

I'd love some (brutally honest) feedback on this refactoring - if it sucks, I want to know because I care about the state of this repository. 5abcc5a2d2a7eec5b1ba867755334ac0d3f5ce53 is probably the most important one. I made a preliminary change to the way input is handled, while also trying to fix up so code/documentation in some places. Predominant goals of this "spike":

# Break down `handle_input`
I changed CI in this PR to make linting run the `clippy::pedantic` category, and along with fixing a bunch of small things also tried to break down `handle_input` because clippy complained that the function was more than 100 lines. I think I will try and move the handling into `input.rs` as seen in https://github.com/ndd7xv/heh/pull/22.

# Make future features easier to implement 
Instead of a series `if` statements to determine what the `handle_input` function should do, I created the trait `InputHandler` and anything that implements it should be able to uniquely handle input. 

My reasoning behind this is that 1) the `if` logic was hard to follow and 2) as we build out more features (like maybe control+find, or a help "page" which is a popup over the entire screen you can arrow through for information) this makes it easier to have these new features handle input differently.

# Make things more readable
Honestly, this might be a mild step back. I had tried to aggregate necessary fields in `ApplicationData` so that `InputHandler`'s parameters weren't so long, but this leads to an extra step to get to a field (for example, `app_info.offset` instead of just `offset).

Tried to add some documentation/comments here and there, but it's still very much a WIP.