### PR TITLE
fix: resize issues

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -146,7 +146,7 @@ impl Application {
     /// Renders the display. This is a wrapper around [`ScreenHandler`'s
     /// render](ScreenHandler::render) method.
     fn render_display(&mut self) -> Result<(), Box<dyn Error>> {
-        self.display.render(&self.data, &self.labels, self.key_handler.as_ref())?;
+        self.display.render(&mut self.data, &self.labels, self.key_handler.as_ref())?;
         Ok(())
     }
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -79,25 +79,14 @@ pub(crate) fn adjust_offset(
     display: &mut ScreenHandler,
     labels: &mut LabelHandler,
 ) {
-    let line_adjustment = if app.offset <= app.start_address {
-        app.start_address - app.offset + display.comp_layouts.bytes_per_line - 1
-    } else {
-        app.offset - app.start_address
-    } / display.comp_layouts.bytes_per_line;
-
-    let bytes_per_screen =
-        display.comp_layouts.bytes_per_line * display.comp_layouts.lines_per_screen;
+    let bytes_per_line = display.comp_layouts.bytes_per_line;
+    let bytes_per_screen = bytes_per_line * display.comp_layouts.lines_per_screen;
 
     if app.offset < app.start_address {
+        app.start_address = (app.offset / bytes_per_line) * bytes_per_line;
+    } else if app.offset >= app.start_address + (bytes_per_screen) {
         app.start_address =
-            app.start_address.saturating_sub(display.comp_layouts.bytes_per_line * line_adjustment);
-    } else if app.offset >= app.start_address + (bytes_per_screen)
-        && app.start_address + display.comp_layouts.bytes_per_line < app.contents.len()
-    {
-        app.start_address = app.start_address.saturating_add(
-            display.comp_layouts.bytes_per_line
-                * (line_adjustment + 1 - display.comp_layouts.lines_per_screen),
-        );
+            (app.offset / bytes_per_line) * bytes_per_line - bytes_per_screen + bytes_per_line;
     }
 
     labels.offset = format!("{:#X}", app.offset);


### PR DESCRIPTION
Previously, resizing would always keep the starting address of the bytes the editors displayed fixed. This caused problems with how we calculated where to display the offset.

Now, we readjust offset so that 0 is ALWAYS the beginning offset, which not only fixes some bugs but also made me realize I could simplify `adjust offset` .