### PR TITLE
Option to read file from an offset

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -124,7 +124,11 @@ impl Application {
     /// default. This is called once at the beginning of the program.
     ///
     /// This errors out if the file specified is empty.
-    pub(crate) fn new(mut file: File, encoding: Encoding, offset: usize) -> Result<Self, Box<dyn Error>> {
+    pub(crate) fn new(
+        mut file: File,
+        encoding: Encoding,
+        offset: usize,
+    ) -> Result<Self, Box<dyn Error>> {
         let mut contents = Vec::new();
         file.seek(std::io::SeekFrom::Start(offset as u64))?;
         file.read_to_end(&mut contents).expect("Reading the contents of the file was interrupted.");

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@
 //! The application holds the main components of the other modules, like the [`ScreenHandler`],
 //! [`LabelHandler`], and input handling, as well as the state data that each of them need.
 
+use std::io::Seek;
 use std::{
     collections::hash_map::DefaultHasher, error::Error, fs::File, hash::Hasher, io::Read, process,
 };
@@ -123,8 +124,9 @@ impl Application {
     /// default. This is called once at the beginning of the program.
     ///
     /// This errors out if the file specified is empty.
-    pub(crate) fn new(mut file: File, encoding: Encoding) -> Result<Self, Box<dyn Error>> {
+    pub(crate) fn new(mut file: File, encoding: Encoding, offset: usize) -> Result<Self, Box<dyn Error>> {
         let mut contents = Vec::new();
+        file.seek(std::io::SeekFrom::Start(offset as u64))?;
         file.read_to_end(&mut contents).expect("Reading the contents of the file was interrupted.");
         if contents.is_empty() {
             eprintln!("heh does not support editing empty files");

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,7 +6,7 @@
 use std::{
     cmp,
     error::Error,
-    io::{Seek, SeekFrom, Write},
+    io::{Seek, Write},
 };
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -108,7 +108,7 @@ pub(crate) fn handle_character_input(
                 }
             }
             's' => {
-                app.data.file.seek(SeekFrom::Start(0))?;
+                app.data.file.rewind()?;
                 app.data.file.write_all(&app.data.contents)?;
                 app.data.file.set_len(app.data.contents.len() as u64)?;
 
@@ -396,7 +396,7 @@ fn handle_editor_drag(
                 mouse.column = end_of_row;
             }
         }
-        mouse.row = editor_bottom_row - if click_past_contents { 0 } else { 1 };
+        mouse.row = editor_bottom_row - u16::from(!click_past_contents);
         if let Some(mut result) = handle_editor_cursor_action(window, app, mouse) {
             if let Some(new_y) = result.0.checked_add(app.display.comp_layouts.bytes_per_line) {
                 if new_y < app.data.contents.len() {

--- a/src/label.rs
+++ b/src/label.rs
@@ -128,7 +128,7 @@ impl LabelHandler {
         self.signed_sixtyfour = i64::from_le_bytes(bytes.try_into().unwrap()).to_string();
     }
     fn update_unsigned_eight(&mut self, bytes: &[u8]) {
-        self.unsigned_eight = (bytes[0] as u8).to_string();
+        self.unsigned_eight = (bytes[0]).to_string();
     }
     fn update_unsigned_sixteen(&mut self, bytes: &[u8]) {
         self.unsigned_sixteen = u16::from_le_bytes(bytes.try_into().unwrap()).to_string();

--- a/src/label.rs
+++ b/src/label.rs
@@ -70,11 +70,11 @@ impl Index<&str> for LabelHandler {
 }
 
 impl LabelHandler {
-    pub(crate) fn new(bytes: &[u8]) -> Self {
+    pub(crate) fn new(bytes: &[u8], offset: usize) -> Self {
         let mut labels = Self { ..Default::default() };
         labels.update_stream_length(8);
-        labels.update_all(bytes);
-        labels.offset = String::from("0x0");
+        labels.update_all(&bytes[offset..]);
+        labels.offset = format!("{offset:#X?}");
         labels
     }
     pub(crate) fn update_all(&mut self, bytes: &[u8]) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,10 +70,10 @@ impl From<EncodingOption> for Encoding {
 }
 
 fn parse_hex_or_dec(arg: &str) -> Result<usize, String> {
-    if arg.starts_with("0x") {
-        usize::from_str_radix(&arg[2..], 16).map_err(|e| format!("Invalid hexadecimal number: {}", e))
+    if let Some(striped) = arg.strip_prefix("0x") {
+        usize::from_str_radix(striped, 16).map_err(|e| format!("Invalid hexadecimal number: {e}"))
     } else {
-        arg.parse().map_err(|e| format!("Invalid decimal number: {}", e))
+        arg.parse().map_err(|e| format!("Invalid decimal number: {e}"))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,14 @@ impl From<EncodingOption> for Encoding {
     }
 }
 
+fn parse_hex_or_dec(arg: &str) -> Result<usize, String> {
+    if arg.starts_with("0x") {
+        usize::from_str_radix(&arg[2..], 16).map_err(|e| format!("Invalid hexadecimal number: {}", e))
+    } else {
+        arg.parse().map_err(|e| format!("Invalid decimal number: {}", e))
+    }
+}
+
 /// Opens the specified file, creates a new application and runs it!
 fn main() -> Result<(), Box<dyn Error>> {
     let matches = command!()
@@ -84,6 +92,15 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .possible_values(EncodingOption::variants())
                 .default_value("Ascii"),
         )
+        .arg(
+            Arg::new("Offset")
+                .help("Read file at offset (indicated by a decimal or hexadecimal number)")
+                .long("offset")
+                .required(false)
+                .case_insensitive(true)
+                .value_parser(parse_hex_or_dec)
+                .default_value("0"),
+        )
         .arg(Arg::new("FILE").required(true))
         .get_matches();
 
@@ -97,8 +114,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         .write(true)
         .open(matches.get_one::<String>("FILE").unwrap())?;
     let encoding = value_t!(matches, "Encoding", EncodingOption)?;
+    let offset = *matches.get_one::<usize>("Offset").unwrap();
 
-    let mut app = Application::new(file, encoding.into())?;
+    let mut app = Application::new(file, encoding.into(), offset)?;
     app.run()?;
 
     Ok(())

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -174,7 +174,7 @@ impl ScreenHandler {
         let address_text = (0..cmp::min(lines_per_screen, content_lines - start_row))
             .map(|i| {
                 let row_address = app_info.start_address + i * bytes_per_line;
-                let mut span = Span::from(format!("{:08X?}\n", row_address));
+                let mut span = Span::from(format!("{row_address:08X?}\n"));
                 // Highlight the address row that the cursor is in for visibility
                 if (row_address..row_address + bytes_per_line).contains(&app_info.offset) {
                     span.style = span.style.fg(Color::Black).bg(Color::White);


### PR DESCRIPTION
Closes #38 and fixes some linting issues.

Added an `--offset` option to allow read file from a given offset. The behavior of the option is described as below:

- It supports both decimal and hexadecimal numbers.
- It doesn't support negative numbers.
- When it is larger than file size, it follows the current logic of handling an "empty" file: prints out a warning and exits. We should think about this more carefully.