### PR TITLE
Switch from loading full file into buffer to memmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset 0.8.0",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,7 +308,9 @@ version = "0.3.1"
 dependencies = [
  "arboard",
  "clap",
+ "crossbeam",
  "crossterm",
+ "memmap2",
  "ratatui",
 ]
 
@@ -315,10 +384,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -344,7 +431,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ tui = {package = "ratatui", version = "0.21", default-features = false, features
 crossterm = "0.26"
 clap = { version = "4.3", features = ["derive"] }
 arboard = { version = "3.2", default-features = false }
+memmap2 = "0.5.10"
+crossbeam = "0.8.2"
 
 [profile.dev]
 opt-level = 1 # Default would excessively lag

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,0 +1,218 @@
+use std::{
+    error::Error,
+    ops::{Deref, DerefMut},
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+use memmap2::{MmapMut, MmapOptions};
+
+const SYNC_BUFF_LEN: usize = 0x10000;
+
+/// Messages that the background thread processes to modify the buffer outside
+/// of the main rendering thread.
+enum EditMessage {
+    Remove,
+    Add(u8), // The byte to add to the front of the buffer that got cut off synchronously
+    ModifyWindow(usize), // New offset to sync the window to
+}
+
+/// Struct to encapsulate a memory mapped buffer. Memmap is unsafe due to the fact
+/// that it is backed by a file that could be removed. To make it safer, the file
+/// can be locked. This struct also implements deref to much more easily control
+/// the content the rest of the application can see without massively restructuring.
+pub(crate) struct AsyncBuffer {
+    /// The mmap backed by the file that is being edited
+    content_buf: MmapMut,
+    /// The length of the content. Used for when elements are deleted
+    len: usize,
+    /// A mpsc channel that allows sending messages to a thread that finishes
+    /// updating the buffer if it is very large. Makes it much more responsive
+    tx: crossbeam::channel::Sender<EditMessage>,
+    /// An atomic that denotes whether the background buffer is actively engaged in work
+    has_work: Arc<AtomicBool>,
+    /// An offset shared between the processing thread and the main thread. This is to safely
+    /// work on the ultimately same buffer by splitting it into 2 independent slices
+    window_end: Arc<AtomicUsize>,
+}
+
+impl Deref for AsyncBuffer {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.content_buf[..self.len]
+    }
+}
+
+impl DerefMut for AsyncBuffer {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.content_buf[..self.len]
+    }
+}
+
+impl AsyncBuffer {
+    /// Create 2 copy-on-write memmaps of the same file. Since they are shared,
+    /// they edit the same underlying buffer. Store one of the buffers for use
+    /// for background processing by [`AsyncBuffer::process_messages`]
+    pub fn new(file: &std::fs::File) -> Result<Self, Box<dyn Error>> {
+        let mut content_buf = unsafe { MmapOptions::new().map_copy(file)? };
+        let internal_buf = content_buf.as_mut_ptr();
+
+        let has_work = Arc::new(AtomicBool::new(false));
+
+        // This is ok, because it is the len of a memmap buffer, it is limited
+        // by the size of the addressing space anyways.
+        #[allow(clippy::cast_possible_truncation)]
+        let window_end =
+            Arc::new(AtomicUsize::new(SYNC_BUFF_LEN.min(file.metadata()?.len() as usize)));
+
+        let (tx, rx) = crossbeam::channel::unbounded();
+
+        AsyncBuffer::process_messages(
+            #[allow(clippy::cast_possible_truncation)]
+            (internal_buf, file.metadata()?.len() as usize),
+            rx,
+            has_work.clone(),
+            window_end.clone(),
+        );
+
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(Self { content_buf, len: file.metadata()?.len() as usize, tx, has_work, window_end })
+    }
+
+    /// Receives messages of type [`EditMessage`], and processes the buffer in the
+    /// background. Although this uses unsafe in both the ptr copy and the 2 mutable
+    /// buffers, it is still safe. This uses a channel to receive the messages in order.
+    /// Once received, it does the copy to insert / remove where the main thread stopped.
+    /// This *vastly* improves snappiness and feel and does not overlap in read / write
+    /// with the main thread, thus preventing any UB in writing to the same section of
+    /// the buffer
+    fn process_messages(
+        internal_buf: (*mut u8, usize),
+        rx: crossbeam::channel::Receiver<EditMessage>,
+        has_work: Arc<AtomicBool>,
+        window_offset: Arc<AtomicUsize>,
+    ) {
+        let internal_buf =
+            unsafe { std::slice::from_raw_parts_mut(internal_buf.0, internal_buf.1) };
+        let mut internal_start = window_offset.load(Ordering::SeqCst);
+
+        std::thread::spawn(move || loop {
+            for rcv in rx.iter() {
+                has_work.store(true, Ordering::SeqCst);
+
+                let start = window_offset.load(Ordering::SeqCst);
+                let internal_buf = &mut internal_buf[start..];
+
+                match rcv {
+                    EditMessage::Remove => unsafe {
+                        debug_assert!(internal_start >= start);
+
+                        std::ptr::copy(
+                            internal_buf.as_ptr().add(internal_start - start),
+                            internal_buf.as_mut_ptr(),
+                            internal_buf.len() - (internal_start - start),
+                        );
+
+                        internal_start = start;
+                    },
+                    EditMessage::Add(byte) => unsafe {
+                        debug_assert_eq!(internal_start, window_offset.load(Ordering::SeqCst));
+
+                        std::ptr::copy(
+                            internal_buf.as_ptr(),
+                            internal_buf.as_mut_ptr().add(1),
+                            internal_buf.len() - 1,
+                        );
+
+                        internal_buf[0] = byte;
+                    },
+                    EditMessage::ModifyWindow(new_window) => {
+                        window_offset.store(new_window, Ordering::SeqCst);
+                        internal_start = new_window;
+                    }
+                }
+
+                has_work.store(rx.is_full(), Ordering::SeqCst);
+            }
+        });
+    }
+
+    /// Returns the length accounting for deletes
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Removes the value, and then copies the rest of the buffer 1 previous
+    /// up to the offset of the internal window. After this, it has the background
+    /// thread process the rest.
+    pub fn remove(&mut self, offset: usize) -> u8 {
+        let val = self.content_buf[offset];
+
+        unsafe {
+            std::ptr::copy(
+                self.content_buf.as_ptr().add(offset + 1),
+                self.content_buf.as_mut_ptr().add(offset),
+                self.window_end.fetch_sub(1, Ordering::SeqCst) - offset,
+            );
+        }
+
+        self.tx.send(EditMessage::Remove).unwrap();
+        self.len -= 1;
+
+        val
+    }
+
+    /// At the moment, only used for undoing deletions. With that in mind,
+    /// no need to worry about increasing the size of the buffer. Copies
+    /// up to the window so a single byte will be cut off at the end. Sends
+    /// this byte so the background thread can re-insert it once it is safe.
+    pub fn insert(&mut self, offset: usize, byte: u8) {
+        let window_end = self.window_end.load(Ordering::SeqCst);
+        self.tx.send(EditMessage::Add(self.content_buf[window_end - 1])).unwrap();
+        self.len += 1;
+
+        unsafe {
+            std::ptr::copy(
+                self.content_buf.as_ptr().add(offset),
+                self.content_buf.as_mut_ptr().add(offset + 1),
+                window_end.saturating_sub(offset).saturating_sub(1),
+            );
+        }
+
+        self.content_buf[offset] = byte;
+    }
+
+    /// Compute whether the window needs to be extended, blocks if so until there is no
+    /// more work to prevent data from being inserter / removed in the wrong places.
+    pub fn compute_new_window(&mut self, new_offset: usize) {
+        let window_end = self.window_end.load(Ordering::SeqCst);
+        // If the distance of the current offset to the end of the window is less than a
+        // third of the SYNC_BUFF_LEN then increase the window.
+        // OR
+        // If the new offset is sufficiently far away from the end of the window, shrink the
+        // window. We want to do this because if we never shrink the window, then editing at
+        // the end of the file creates a large buffer that will have to sync on deletions,
+        // thus blocking the user and defeating the point of all this.
+        //
+        // This is set behind this if to prevent rerunning every single frame and cause a
+        // potential performance hit.
+        if window_end.saturating_sub(new_offset) < SYNC_BUFF_LEN / 3
+            || window_end.saturating_sub(new_offset) > SYNC_BUFF_LEN * 4 / 3
+        {
+            self.block();
+            self.tx
+                .send(EditMessage::ModifyWindow((new_offset + SYNC_BUFF_LEN).min(self.len)))
+                .unwrap();
+        }
+    }
+
+    /// Wait until the background thread has finished processing messages
+    pub fn block(&self) {
+        while self.has_work.load(Ordering::SeqCst) {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use app::Application;
 use crate::decoder::Encoding;
 
 mod app;
+mod buffer;
 mod character;
 mod chunk;
 mod decoder;

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -204,6 +204,8 @@ impl ScreenHandler {
         labels: &LabelHandler,
         window: &dyn KeyHandler,
     ) -> Result<(), Box<dyn Error>> {
+        app_info.contents.compute_new_window(app_info.offset);
+
         self.terminal.draw(|f| {
             // We check if we need to recompute the terminal size in the case that the saved off
             // variable differs from the current frame, which can occur when a terminal is resized

--- a/src/windows/editor.rs
+++ b/src/windows/editor.rs
@@ -149,7 +149,7 @@ impl KeyHandler for Editor {
         labels: &mut LabelHandler,
     ) {
         if app.offset > 0 {
-            app.actions.push(Action::Backspace(
+            app.actions.push(Action::Delete(
                 app.offset.saturating_sub(1),
                 app.contents.remove(app.offset - 1),
             ));
@@ -187,6 +187,7 @@ impl KeyHandler for Editor {
                     None,
                 ));
                 app.contents[app.offset] = c as u8;
+                app.dirty = true;
                 app.offset = cmp::min(app.offset.saturating_add(1), app.contents.len() - 1);
                 labels.update_all(&app.contents[app.offset..]);
                 adjust_offset(app, display, labels);
@@ -225,6 +226,7 @@ impl KeyHandler for Editor {
                         }
                     }
                     app.nibble.toggle();
+                    app.dirty = true;
                 } else {
                     labels.notification = format!("Invalid Hex: {c}");
                 }

--- a/src/windows/search.rs
+++ b/src/windows/search.rs
@@ -117,7 +117,7 @@ pub(crate) fn perform_search(
     }
 
     // Cached search data may be invalidated if contents have changed
-    if app.hash_contents() != app.hashed_contents {
+    if app.dirty {
         app.reindex_search();
     }
 


### PR DESCRIPTION
This PR stops heh from loading the entire file into a buffer. For large files, this is basically a non starter. On my linux desktop with a 3700x and 32GB of ram, I had to restart my computer after it froze to a halt from trying to load a 16GB file.

This makes it MUCH snappier and faster editing and deleting with large files. This, howerver, adds unsafety in the buffer.rs file that is added. However, it still prevents reading and writing to the same memory region at the same time by doing some of the computation in the main thread, and only sending a message over a channel to the background thread to resume computation. If multiple deletes / insertions occur shortly after the other, the channel ensures in-order processing so they do not get out of order.

I tried multiple options before moving to unsafe, but using things like BufReader and trying to split the contents into files simply did not reach the performance constraints. As a result, I have found that memmap to be the best option and letting the host OS handle the conversion.

I have only been able to test this on linux 6.2.9, so helping test on both windows, mac, and older version of linux would be helpful.

To test this on a large file, you can use `fallocate -l 14G /tmp/largefile` which will create a 14GB file which will struggle to load on heh as is, but on this patch loads instantly and allows instant editing. 