### PR TITLE
Fixed double key presses on windows due to crossterm changes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6,7 +6,7 @@
 use std::{error::Error, fs::File, process};
 
 use arboard::Clipboard;
-use crossterm::event::{self, Event};
+use crossterm::event::{self, Event, KeyEventKind};
 
 use crate::buffer::AsyncBuffer;
 use crate::decoder::Encoding;
@@ -219,8 +219,10 @@ impl Application {
         let event = event::read()?;
         match event {
             Event::Key(key) => {
-                self.labels.notification.clear();
-                return input::handle_key_input(self, key);
+                if key.kind == KeyEventKind::Press {
+                    self.labels.notification.clear();
+                    return input::handle_key_input(self, key);
+                }
             }
             Event::Mouse(mouse) => {
                 self.labels.notification.clear();


### PR DESCRIPTION
I tried to cargo install heh on windows, and all the key presses were handled as if they were duplicated, making it unusable.
I did some digging and found this issue on `crossterm`:
[https://github.com/crossterm-rs/crossterm/issues/797](https://github.com/crossterm-rs/crossterm/issues/797)
Bascially, after the update to 0.26, on windows, `crossterm` reports key releases in addition to key presses instead of only key presses.
I changed the `handle_input` function in `app.rs` to ignore key inputs other than presses, as recommended in the issue previously mentioned.
This seems to solve the issue without having any adverse effects, but I've only tested on windows. 