### PR TITLE
chore(release): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish on crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Publish
+        run: cargo publish --locked --token ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Adding this automation so that we don't have to run `cargo publish` manually.

@ndd7xv can you add your crates.io token as a secret (`CARGO_REGISTRY_TOKEN`) or maybe invite me to <https://crates.io/crates/heh>?
