### PR TITLE
chore(release): prepare for 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project _somewhat_ adheres to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.6.0] - 2024-07-28
+
+- Support searching by hex
+- Remove 0x searching functionality
+- Bump ratatui from 0.26.1 to 0.26.2
+
 ## [0.5.0] - 2023-04-08
 
 - Fixed a bug where '--version' did not print `heh`'s version (thanks for the report, [@davidak](https://github.com/davidak))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heh"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heh"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A cross-platform terminal UI used for modifying file data in hex or ASCII."
 readme = "README.md"


### PR DESCRIPTION
🥳
