### PR TITLE
chore(release): prepare for 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project _somewhat_ adheres to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-01-14
+
+- Bump ratatui from 0.29.0 to 0.30.0
+- Bump clap from 4.5.40 to 4.5.54
+- Bump actions/checkout from 4 to 6
+- Bump memmap2 from 0.9.7 to 0.9.9
+- Bump arboard from 3.6.0 to 3.6.1
+
 ## [0.6.2] - 2025-12-11
 
 - Add demo example and update documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heh"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heh"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 description = "A cross-platform terminal UI used for modifying file data in hex or ASCII."
 readme = "README.md"


### PR DESCRIPTION
Bumps Ratatui to 0.30!

required for https://github.com/orhun/binsider/pull/138

@ndd7xv hope you don't mind me merging this directly, but it's just dependency bumps :)
